### PR TITLE
Corrigido link de confirmacao de cadastro

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,4 +3,4 @@
 <p><%= t('.instruction', :default => "You can confirm your account email through the link below:") %></p>
 
 <p><%= link_to t('.action', :default => "Confirm my account"),
-         confirmation_url(@resource, :confirmation_token => @resource.confirmation_token) %></p>
+         confirmation_url(@resource, :confirmation_token => @token) %></p>


### PR DESCRIPTION
Corrigido. Não é mais utilizado o token que fica armazenado no banco para o link. http://blog.plataformatec.com.br/2013/08/devise-3-1-now-with-more-secure-defaults/ . Closes #38
