### PR TITLE
Registro pelo Twitter Corrigido

### DIFF
--- a/app/controllers/users/auth/confirm_controller.rb
+++ b/app/controllers/users/auth/confirm_controller.rb
@@ -1,0 +1,12 @@
+class Users::Auth::ConfirmController < ApplicationController
+  def create
+    omniauth_data = OmniAuth::AuthHash.new(session[:omniauth])
+    @user = User.find_or_initialize_by_oauth(omniauth_data, current_user)
+    @user.email = params[:user][:email] if params[:user]
+    if @user.save
+      session[:omniauth] = nil
+      sign_in(@user)
+    end
+    respond_with(@user)
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,11 +4,8 @@ module Users
     self.responder = OauthResponder
 
     def create
-      omniauth_data = env["omniauth.auth"] || OmniAuth::AuthHash.new(session[:omniauth])
-      @user = User.find_or_initialize_by_oauth(omniauth_data, current_user)
-      @user.email = params[:user][:email] if params[:user]
+      @user = User.find_or_initialize_by_oauth(env["omniauth.auth"], current_user)
       if @user.save
-        session[:omniauth] = nil
         sign_in(@user)
       else
         session[:omniauth] = env["omniauth.auth"].except('extra')

--- a/app/responders/oauth_responder.rb
+++ b/app/responders/oauth_responder.rb
@@ -5,7 +5,7 @@ class OauthResponder < ApplicationResponder
 
   def navigation_behavior(error)
     if has_errors?
-      render 'users/omniauth_callbacks/new'
+      render 'users/auth/confirm/new'
     else
       redirect_to navigation_location
     end

--- a/app/views/users/auth/confirm/new.html.erb
+++ b/app/views/users/auth/confirm/new.html.erb
@@ -3,7 +3,7 @@
     <h2><%= t('devise.registrations.new.sign_up', :default => "Sign up") %></h2>
   </div>
 
-  <%= simple_form_for(@user, as: resource_name, url: user_omniauth_callback_path(action_name)) do |f| %>
+  <%= simple_form_for(@user, url: users_auth_confirm_path) do |f| %>
     <%= f.input :email %>
 
     <%= f.button :submit, t('devise.registrations.new.sign_up', :default => "Sign up"), class: 'btn-primary pull-right' %>

--- a/config/locales/br/gems/responders.yml
+++ b/config/locales/br/gems/responders.yml
@@ -20,3 +20,7 @@ br:
           notice: 'Autorizado com sucesso de uma conta do Twitter.'
         linkedin:
           notice: 'Autorizado com sucesso de uma conta do Linkedin.'
+      auth:
+        confirm:
+          create:
+            notice: 'Autorizado com sucesso de uma conta do Twitter.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,12 @@ Rails.application.routes.draw do
              as: :user_registration
   end
 
+  namespace :users do
+    namespace :auth do
+      resource :confirm, only: :create, controller: :confirm
+    end
+  end
+
   get '/' => 'root#index', as: :users
   root to: 'root#index'
 end

--- a/spec/features/visitor_signs_up_spec.rb
+++ b/spec/features/visitor_signs_up_spec.rb
@@ -44,4 +44,15 @@ feature "Visitor shouldn't be able to sign up" do
     expect(current_path).to be == new_user_session_path
     expect(page).to have_content('Não foi possível autorizar de uma conta do Facebook porque "Invalid credentials".')
   end
+
+  scenario 'with twitter without fill the email field' do
+    visit(new_user_session_path)
+    click_link('Entrar com Twitter')
+
+    within('#new_user') do
+      click_button('Inscrever-se')
+    end
+
+    expect(page).to have_content('não pode ficar em branco')
+  end
 end


### PR DESCRIPTION
Ao voltar do twitter a aplicação estava gerando um formulário com dados
para enviar para a url de callback novamente, mas por não enviar todos
os dados (alguns estavam na sessão) a requisição não era válida.

Para corrigir, foi criada uma nova rota, e no caso do twitter, o
formulário irá enviar os dados para essa nova rota que cria o usuário
direto, sem passar pelo omniauth. Essa rota pega os dados da sessão,
insere o email digitado pelo usuário e salva no banco de dados.
