### PR TITLE
Adicionando a gem brakeman ao projeto

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 
 group :development do
   gem 'letter_opener'
+  gem 'brakeman', :require => false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,17 @@ GEM
     bcrypt (3.1.7)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    brakeman (2.6.1)
+      erubis (~> 2.6)
+      fastercsv (~> 1.5)
+      haml (>= 3.0, < 5.0)
+      highline (~> 1.6.20)
+      multi_json (~> 1.2)
+      ruby2ruby (~> 2.0.5)
+      ruby_parser (~> 3.5.0)
+      sass (~> 3.0)
+      slim (>= 1.3.6, < 3.0)
+      terminal-table (~> 1.4)
     builder (3.2.2)
     byebug (2.7.0)
       columnize (~> 0.3)
@@ -94,6 +105,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    fastercsv (1.5.5)
     ffi (1.9.3)
     formatador (0.2.5)
     grit (2.5.0)
@@ -109,7 +121,10 @@ GEM
     guard-rspec (4.3.1)
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
+    haml (4.0.5)
+      tilt
     hashie (3.2.0)
+    highline (1.6.21)
     hike (1.2.3)
     hirb (0.7.2)
     i18n (0.6.11)
@@ -254,6 +269,13 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.3)
+    ruby2ruby (2.0.8)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.5.0)
+      sexp_processor (~> 4.1)
+    sass (3.3.14)
+    sexp_processor (4.4.3)
     shoulda-matchers (2.6.2)
       activesupport (>= 3.0.0)
     simple_form (3.1.0.rc2)
@@ -264,6 +286,9 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    slim (2.0.3)
+      temple (~> 0.6.6)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     spring (1.1.3)
     spring-commands-rspec (1.0.2)
@@ -278,8 +303,10 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.9)
+    temple (0.6.8)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
+    terminal-table (1.4.5)
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
@@ -307,6 +334,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brakeman
   cancancan
   capybara
   coveralls


### PR DESCRIPTION
A gem brakeman serve para procurar erros conhecidos no código do rails, manter ela atualizada deve ser algo a ser perseguido no projeto e não deveríamos aceitar commits que adicionem bugs de segurança.
