### PR TITLE
Atualizado configs do hound para a nova sintaxe do Rubocop

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,26 +1,14 @@
-MethodCalledOnDoEndBlock:
+Metrics/LineLength:
+  Max: 125
+
+Style/InlineComment:
   Enabled: true
 
-HashSyntax:
-  Enabled: false
-
-LineLength:
-  Enabled: false
-
-SingleSpaceBeforeFirstArg:
-  Enabled: false
-
-SpaceInsideBrackets:
-  Enabled: false
-
-StringLiterals:
-  Enabled: false
-
-SymbolArray:
+Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
-TrailingBlankLines:
+Style/StringLiterals:
   Enabled: false
 
-TrailingWhitespace:
-  Enabled: false
+Style/SymbolArray:
+  Enabled: true


### PR DESCRIPTION
A ultima versao do rubocop mudou a sintaxe das cops. com isso o que tinhamos estava sendo ignorado pois nao era reconhecido. Com essas modificacoes, nossas definicoes seram corretamente reconhecidas e utilizadas.
