### PR TITLE
Verifica se uma url é válida

### DIFF
--- a/app/models/cast.rb
+++ b/app/models/cast.rb
@@ -25,15 +25,15 @@ class Cast < ActiveRecord::Base
   delegate :can_transition_to?, :transition_to!, :transition_to, :current_state, to: :state_machine
 
   private
-    def regular_url
-      errors.add(:url, :bad_url) unless is_valid_url?
-    end
 
-    def is_valid_url?
-      uri = URI.parse(url)
-      uri.kind_of?(URI::HTTP)
-      rescue URI::InvalidURIError
-        false
-    end
+  def regular_url
+    errors.add(:url, :bad_url) unless valid_url?
+  end
 
+  def valid_url?
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP)
+    rescue URI::InvalidURIError
+      false
+  end
 end

--- a/app/models/cast.rb
+++ b/app/models/cast.rb
@@ -12,6 +12,7 @@ class Cast < ActiveRecord::Base
   scope :by_user, -> (user_id) { where(user_id: user_id) }
 
   validates_presence_of :name, :url
+  validate :regular_url
 
   auto_html_for :url do
     youtube(width: "100%", height: 550, autoplay: true)
@@ -22,4 +23,17 @@ class Cast < ActiveRecord::Base
   end
 
   delegate :can_transition_to?, :transition_to!, :transition_to, :current_state, to: :state_machine
+
+  private
+    def regular_url
+      errors.add(:url, :bad_url) unless is_valid_url?
+    end
+
+    def is_valid_url?
+      uri = URI.parse(url)
+      uri.kind_of?(URI::HTTP)
+      rescue URI::InvalidURIError
+        false
+    end
+
 end

--- a/app/views/casts/new.html.erb
+++ b/app/views/casts/new.html.erb
@@ -1,12 +1,12 @@
 <section class="new-cast">
   <div class="container">
-  
+
   	<% if flash[:notice] %>
 		  <div class="col-md-12">
 		  		<%= flash[:notice] %>
 		  </div>
 	  <% end %>
-  
+
     <div class="col-md-12">
       <%= form_for @cast do |f| %>
         <div class="panel panel-default">
@@ -21,7 +21,7 @@
 
               <div class="form-group">
                 <%= f.label :url %>
-                <%= f.text_field :url, placeholder: 'URL da Screencast', class: 'form-control' %>
+                <%= f.url_field :url, placeholder: 'URL da Screencast', class: 'form-control' %>
               </div>
 
               <div class="form-group">

--- a/config/locales/br/models/cast.yml
+++ b/config/locales/br/models/cast.yml
@@ -8,3 +8,9 @@ br:
         name: 'Nome'
         url: 'Url'
         description: 'Descrição'
+    errors:
+      models:
+        cast:
+          attributes:
+            url:
+              bad_url: "Url inválida"

--- a/spec/factories/casts.rb
+++ b/spec/factories/casts.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :cast do
-    name "MyString"
-    description "MyText"
-    url "MyString"
+    name "Cast 1"
+    description "some description"
+    url "https://foo.com"
     user nil
   end
 end

--- a/spec/models/cast_spec.rb
+++ b/spec/models/cast_spec.rb
@@ -72,4 +72,15 @@ describe Cast do
       end
     end
   end
+
+  describe 'valid urls' do
+    it "it's a url" do
+      expect(cast.send(:is_valid_url?)).to eq(true)
+    end
+
+    it "should be a regular url" do
+      expect(cast.errors[:url]).to be_empty
+    end
+
+  end
 end

--- a/spec/models/cast_spec.rb
+++ b/spec/models/cast_spec.rb
@@ -75,12 +75,11 @@ describe Cast do
 
   describe 'valid urls' do
     it "it's a url" do
-      expect(cast.send(:is_valid_url?)).to eq(true)
+      expect(cast.send(:valid_url?)).to eq(true)
     end
 
     it "should be a regular url" do
       expect(cast.errors[:url]).to be_empty
     end
-
   end
 end


### PR DESCRIPTION
dois métodos que previnem o usuário de criar um cast com uma bad url
achei isso aqui http://gdata.youtube.com/feeds/api/videos/video_id pra validar a url do youtube, mas não consegui fazer funcionar com nenhum vídeo, assim que fazer isso funcionar mando outro pull :smile:   
